### PR TITLE
Replace {{ current_site }} with "foobar.com".

### DIFF
--- a/newsletter/templates/newsletter/subscription_subscribe.html
+++ b/newsletter/templates/newsletter/subscription_subscribe.html
@@ -9,7 +9,7 @@
 		<p>{% trans "Due to a technical error we were not able to submit your confirmation email. This could be because your email address is invalid." %}</p>
 		{% comment %} Replace the the following dummy with a valid email address and remove this comment.
 
-		<p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com }}">info@foobar.com }}</a></p>
+		<p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com">info@foobar.com</a></p>
 
 		{% endcomment %}
 	{% else %}

--- a/newsletter/templates/newsletter/subscription_update.html
+++ b/newsletter/templates/newsletter/subscription_update.html
@@ -10,7 +10,7 @@
 
 		{% comment %} Replace the the following dummy with a valid email address and remove this comment.
 
-		<p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com }}">info@foobar.com }}</a></p>
+		<p>{% trans "If the error persists, please don't hesitate to contact us at the following email address:" %} <a href="mailto:info@foobar.com">info@foobar.com</a></p>
 
 		{% endcomment %}
 	{% else %}


### PR DESCRIPTION
Additionally, enclose the error in a comment-block so that the embarrassing
"foobar.com" does not get displayed by accident.

This pull request references issue #41.
