### PR TITLE
Fix JavaScript error on "Add submission" page

### DIFF
--- a/newsletter/static/newsletter/admin/js/submit_interface.js
+++ b/newsletter/static/newsletter/admin/js/submit_interface.js
@@ -2,16 +2,21 @@ var SubmitInterface = {
     changed: false,
 
     init: function(submitname) {
-        submitlink = document.getElementById(submitname);
-        submitlink.href = 'javascript:SubmitInterface.process()';
-        addEvent(document.forms[0], "change", function(e) { SubmitInterface.changed = true; });
+        var submitlink = django.jQuery(submitname);
+        submitlink.click(function() {
+            SubmitInterface.process();
+        });
+        submitlink.attr('href', '#');
+        django.jQuery('form:first :input').change(function() {
+            SubmitInterface.changed = true;
+        });
     },
 
     process: function() {
         if (SubmitInterface.changed) {
-            result = confirm(gettext('The submission has been changed. It has to be saved before you can submit. Click OK to proceed with saving, click cancel to continue editing.'));
+            var result = confirm(gettext('The submission has been changed. It has to be saved before you can submit. Click OK to proceed with saving, click cancel to continue editing.'));
             if (result) {
-                document.forms[0]._continue.click();
+                django.jQuery('form:first [name="_continue"]').click();
             }
         } else {
             window.location = 'submit/';

--- a/newsletter/templates/admin/newsletter/submission/change_form.html
+++ b/newsletter/templates/admin/newsletter/submission/change_form.html
@@ -21,6 +21,8 @@
 
 
 {% block after_related_objects %}{{ block.super }}<script type="text/javascript">
-addEvent(window, "load", function(e) { JsonSubscribers.init('id_message'{% if add %}, add=true{% endif %}); });
-addEvent(window, "load", function(e) { SubmitInterface.init('submitlink'); });
+django.jQuery(window).load(function() {
+    JsonSubscribers.init('id_message'{% if add %}, add=true{% endif %});
+    SubmitInterface.init('#submitlink');
+});
 </script>{% endblock %}


### PR DESCRIPTION
On "Add submission" page following error occurred:

```
Uncaught exception: TypeError: Cannot convert 'submitlink' to object
Error thrown at line 6, column 8 in <anonymous function: init>(submitname) in http://127.0.0.1:8000/static/newsletter/admin/js/submit_interface.js:
    submitlink.href = 'javascript:SubmitInterface.process()';
called from line 177, column 64 in <anonymous function>(e) in http://127.0.0.1:8000/admin/newsletter/submission/add/:
    SubmitInterface.init('submitlink');
```

Template admin/newsletter/submission/change_form.htm always tried to add some JavaScript event for `#submitlink`, even on "Add submission" page where there's no `#submitlink`.

Fixed by wrapping relevant JavaScript in template with the same conditions that surround `#submitlink`. But maybe JavaScript should be made more bulletproof?
