### PR TITLE
Fix activate_url in test for update activation

### DIFF
--- a/newsletter/tests/test_web.py
+++ b/newsletter/tests/test_web.py
@@ -925,7 +925,7 @@ class AnonymousSubscribeTestCase(WebSubscribeTestCase,
                                     email='test@email.com')
         subscription.save()
 
-        activate_url = subscription.subscribe_activate_url()
+        activate_url = subscription.update_activate_url()
 
         response = self.client.get(activate_url)
         self.assertInContext(response, 'form', UpdateForm)


### PR DESCRIPTION
In `test_update_request_activate` subscription activation url was used, instead of update activation url.
