### PR TITLE
Fix parsing of requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include COPYRIGHT
 include distribute_setup.py
 include graph_models.*
+include requirements.txt
 recursive-include newsletter/fixtures *.json
 recursive-include newsletter/templates *.html
 recursive-include newsletter/static *

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ chardet
 surlex
 sorl-thumbnail
 
-# Test requirements
-webtest
-django-webtest
+# Manually install these packages for running the tests:
+#webtest
+#django-webtest

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ import distribute_setup
 distribute_setup.use_setuptools('0.6.10')
 
 from setuptools import setup, find_packages
+from pip.req import parse_requirements
 
 try:
     README = open('README.rst').read() + '\n\n'
@@ -31,9 +32,13 @@ except:
     README = None
 
 try:
-    REQUIREMENTS = open('requirements.txt').read()
+    # Idea to use pip to parse requirements from Romain Hardouin:
+    # http://stackoverflow.com/a/16624700/219519
+    REQUIREMENTS = [str(ir.req) for ir in parse_requirements('requirements.txt')]
 except:
     REQUIREMENTS = None
+
+print REQUIREMENTS
 
 setup(
     name='django-newsletter',


### PR DESCRIPTION
During installation with setup.py no requirements are read from requirements.txt. The way `requirements.txt` is read right now, only one string containing all the package names is returned, resulting in `REQUIREMENTS` being `None`. 

Adding `.splitlines()` to `.read()` gives a proper list but also includes comments and other parameters to pip (which might be included), which can be seen below:

```
$ python setup.py --requires
['django-extensions', 'Django>=1.4.5', 'vobject', 'chardet', 'surlex', 'sorl-thumbnail', '', '# Test requirements', 'webtest', 'django-webtest']
```

A better alternative seems using pip's internals to parse the required packages:

```
$ python setup.py --required
['django-extensions', 'Django>=1.4.5', 'vobject', 'chardet', 'surlex', 'sorl-thumbnail', 'webtest', 'django-webtest']
```
