### PR TITLE
Settings class bulletproofing

### DIFF
--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -17,7 +17,7 @@ class Settings(object):
             # DO FUNKY DANCE
 
     If a setting has not been explicitly defined in Django's settings, defaults
-    can be specified as `DEFAULT_SETTING_NAME` class variable or property.
+    can be specified as `_DEFAULT_SETTING_NAME` class variable or property.
     """
 
     def __init__(self, prefix=None):
@@ -37,14 +37,14 @@ class Settings(object):
 
         assert attr.isupper(), 'Requested setting contains lower case characters.'
 
-        if attr.startswith('DEFAULT_'):
+        if attr.startswith('_DEFAULT_'):
             raise AttributeError(
                 '%r object has no attribute %r' % (type(self).__name__, attr)
             )
 
         # Explicit `try: ... except AttributeError: ...`,
         # instead of third argument of getattr is used intentionally
-        # to prevent premature execution of getattr(self, 'DEFAULT_%s' % attr).
+        # to prevent premature execution of getattr(self, '_DEFAULT_%s' % attr).
         try:
             return getattr(
                 django_settings, '%s_%s' % (self.settings_prefix, attr)
@@ -52,25 +52,25 @@ class Settings(object):
         except AttributeError:
             # `django.conf.settings.<APP>_SETTING_NAME` not found
             # return default value.
-            return getattr(self, 'DEFAULT_%s' % attr)
+            return getattr(self, '_DEFAULT_%s' % attr)
 
 
 class NewsletterSettings(Settings):
     """ Django-newsletter specific settings. """
     settings_prefix = 'NEWSLETTER'
 
-    DEFAULT_CONFIRM_EMAIL = True
+    _DEFAULT_CONFIRM_EMAIL = True
 
     @property
-    def DEFAULT_CONFIRM_EMAIL_SUBSCRIBE(self):
+    def _DEFAULT_CONFIRM_EMAIL_SUBSCRIBE(self):
         return self.CONFIRM_EMAIL
 
     @property
-    def DEFAULT_CONFIRM_EMAIL_UNSUBSCRIBE(self):
+    def _DEFAULT_CONFIRM_EMAIL_UNSUBSCRIBE(self):
         return self.CONFIRM_EMAIL
 
     @property
-    def DEFAULT_CONFIRM_EMAIL_UPDATE(self):
+    def _DEFAULT_CONFIRM_EMAIL_UPDATE(self):
         return self.CONFIRM_EMAIL
 
     @property


### PR DESCRIPTION
Previous implementation of Settings class had some flaws.
1. `settings.Settings.__getattr__` was called for all attributes that were not found, even for `DEFAULT_<SETTING_NAME>`. Retrieving `<app>_settings.<SETTING_NAME>`, if neither `django.conf.settings.<APP>_<SETTING_NAME>` nor `<app>_settings.DEFAULT_<SETTING_NAME>` existed would have led to infinite recursion of retrieving `DEFAULT_DEFAULT_DEFAULT_...<SETTING_NAME>`. 
   
   Solved by raising `AttributeError` for nonexistent attribute names starting with prefix denoting default setting.
2. In statement `getattr(obj, 'attr_name', some_function())` function call `some_function()` is always executed, before retrieving `obj.attr_name`. So in `settings.Settings.__getattr__` default setting was always retrieved (though not returned), even if corresponding setting existed in `django.conf.settings`. If e.g. `<SETTING_NAME>` is required and so `DEFAULT_<SETTING_NAME>` is a property that raises `ImproperlyConfigured` exception this exception would have been raised even if `django.conf.settings.<APP>_<SETTING_NAME>` existed.
   
   Fixed by using explicit `try ... except ...`.
3. Using, in an application, setting with name that starts with `DEFAULT_` could have led to unexpected interference with mechanism of retrieving default settings.
   
   Fixed by prefixing default setting names with underscore, so that they are much less likely to cause naming collision.
