### PR TITLE
Add compatibility with Django 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ python:
   - "2.7"
 
 env:
-  - DJANGO=Django==1.4.8
-  - DJANGO=Django==1.5.4
-  - DJANGO=https://www.djangoproject.com/m/releases/1.6/Django-1.6b4.tar.gz
+  - DJANGO=Django==1.4.10
+  - DJANGO=Django==1.5.5
+  - DJANGO=Django==1.6
 
-matrix:
-  allow_failures:
-    # Allow failures for unreleased Django version
-    - env: DJANGO=https://www.djangoproject.com/m/releases/1.6/Django-1.6b4.tar.gz
+# matrix:
+#   allow_failures:
+#     # Allow failures for unreleased Django version
+#     - env: DJANGO=https://www.djangoproject.com/m/releases/1.6/Django-1.6b4.tar.gz
 
 # command to install dependencies
 install:

--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 from django.db import models
 
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from django.contrib import admin, messages
 from django.contrib.sites.models import Site

--- a/newsletter/admin_utils.py
+++ b/newsletter/admin_utils.py
@@ -1,6 +1,6 @@
 from django.http import Http404
 
-from django.utils.functional import update_wrapper
+from functools import update_wrapper
 from django.utils.translation import ugettext_lazy as _
 
 from django.contrib.admin.util import unquote


### PR DESCRIPTION
- `django.conf.urls.defaults` is no longer supported.  
- Django's `EmailValidator` got overhauled, thus the Validator is used directly insted of just the RegEx.
- removal of unused import of `django.template.Template`
- `update_wrapper` got deleted in a PEP8 cleanup and thus needs to be imported directly from `functools`
