### PR TITLE
Make the Submissions list display the Publish date and time with respect to the server's timezone

### DIFF
--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -99,7 +99,7 @@ class SubmissionAdmin(admin.ModelAdmin, ExtendibleModelAdminMixin):
 
     def admin_publish_date(self, obj):
         if obj.publish_date:
-            return date_format(obj.publish_date)
+            return date_format(obj.publish_date, 'DATETIME_FORMAT')
         else:
             return ''
     admin_publish_date.short_description = _("publish date")


### PR DESCRIPTION
To make it clearer when the submissions are getting published, display the published date as well as time, with respect to the server's timezone.
