### PR TITLE
[NEWSLETTER] Settle RemovedInDjango18Warning in Django 1.7.x.

### DIFF
--- a/newsletter/admin_forms.py
+++ b/newsletter/admin_forms.py
@@ -426,6 +426,7 @@ class SubscriptionAdminForm(forms.ModelForm):
 
     class Meta:
         model = Subscription
+        fields = '__all__'
 
     def clean_email_field(self):
         data = self.cleaned_data['email_field']
@@ -459,6 +460,7 @@ class SubmissionAdminForm(forms.ModelForm):
 
     class Meta:
         model = Submission
+        fields = '__all__'
 
     def clean_publish(self):
         """


### PR DESCRIPTION
  *admin_forms.py: Creating a ModelForm without either the 'fields'
   attribute or the 'exclude' attribute is deprecated.

See [doc section](https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#selecting-the-fields-to-use) for use of '__all__' where complete models are to be registered.
