### PR TITLE
[NEWSLETTER] Fix module_name RemovedInDjango18Warning in Django 1.7.x.

### DIFF
--- a/newsletter/admin_utils.py
+++ b/newsletter/admin_utils.py
@@ -38,6 +38,6 @@ class ExtendibleModelAdminMixin(object):
         return update_wrapper(wrapper, view)
 
     def _view_name(self, name):
-        info = self.model._meta.app_label, self.model._meta.module_name, name
+        info = self.model._meta.app_label, self.model._meta.model_name, name
 
         return '%s_%s_%s' % info


### PR DESCRIPTION
Would've rolled this into aead53df7d765dfc8ba8c920028cfd83961d626c but I encountered it on one server and not the other.