### PR TITLE
Hide 'View on site' link if newsletter not visible

### DIFF
--- a/newsletter/templates/admin/newsletter/newsletter/change_form.html
+++ b/newsletter/templates/admin/newsletter/newsletter/change_form.html
@@ -5,7 +5,7 @@
 {% block object-tools %}
 {% if change %}{% if not is_popup %}
   <ul class="object-tools"><li><a href="history/" class="historylink">{% trans "History" %}</a></li>
-  {% if has_absolute_url and original.visible %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %} {{model.visible}}</a></li>{% endif%}
+  {% if has_absolute_url and original.visible %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
   </ul>
 {% endif %}{% endif %}
 {% endblock %}


### PR DESCRIPTION
Small change to hide the 'View on site' button in the admin area if the newsletter has 'Visible' unchecked, since the link leads to a 404 anyway.
