### PR TITLE
Fixing a typo in UpdateSubscriptionView's name

### DIFF
--- a/newsletter/urls.py
+++ b/newsletter/urls.py
@@ -6,7 +6,7 @@ from .views import (
     NewsletterListView, NewsletterDetailView,
     SubmissionArchiveIndexView, SubmissionArchiveDetailView,
     SubscribeRequestView, UnsubscribeRequestView, UpdateRequestView,
-    ActionTemplateView, UpdateSubscriptionViev,
+    ActionTemplateView, UpdateSubscriptionView,
 )
 
 urlpatterns = patterns(
@@ -59,12 +59,12 @@ urlpatterns = patterns(
     surl(
         '^<newsletter_slug:s>/subscription/<email=[-_a-zA-Z0-9@\.\+~]+>/'
         '<action=subscribe|update|unsubscribe>/activate/<activation_code:s>/$',
-        UpdateSubscriptionViev.as_view(), name='newsletter_update_activate'
+        UpdateSubscriptionView.as_view(), name='newsletter_update_activate'
     ),
     surl(
         '^<newsletter_slug:s>/subscription/<email=[-_a-zA-Z0-9@\.\+~]+>/'
         '<action=subscribe|update|unsubscribe>/activate/$',
-        UpdateSubscriptionViev.as_view(), name='newsletter_update'
+        UpdateSubscriptionView.as_view(), name='newsletter_update'
     ),
 
     # Action activation completed view

--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -479,7 +479,7 @@ class UpdateRequestView(ActionRequestView):
         return redirect(self.subscription.update_activate_url())
 
 
-class UpdateSubscriptionViev(ActionFormView):
+class UpdateSubscriptionView(ActionFormView):
     form_class = UpdateForm
     template_name = "newsletter/subscription_activate.html"
 
@@ -490,7 +490,7 @@ class UpdateSubscriptionViev(ActionFormView):
         """
         assert 'email' in kwargs
 
-        super(UpdateSubscriptionViev, self).process_url_data(*args, **kwargs)
+        super(UpdateSubscriptionView, self).process_url_data(*args, **kwargs)
 
         self.subscription = get_object_or_404(
             Subscription, newsletter=self.newsletter,
@@ -509,7 +509,7 @@ class UpdateSubscriptionViev(ActionFormView):
 
     def get_form_kwargs(self):
         """ Add instance to form kwargs. """
-        kwargs = super(UpdateSubscriptionViev, self).get_form_kwargs()
+        kwargs = super(UpdateSubscriptionView, self).get_form_kwargs()
 
         kwargs['instance'] = self.subscription
 
@@ -524,7 +524,7 @@ class UpdateSubscriptionViev(ActionFormView):
 
         subscription.update(self.action)
 
-        return super(UpdateSubscriptionViev, self).form_valid(form)
+        return super(UpdateSubscriptionView, self).form_valid(form)
 
 
 class SubmissionViewBase(NewsletterMixin):


### PR DESCRIPTION
Minor typo in the view name. Since it's a view there shouldn't be any migrations necessary, just code change.
