### PR TITLE
Fix for Submission.publish_date default value

### DIFF
--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -670,7 +670,7 @@ class Submission(models.Model):
 
     publish_date = models.DateTimeField(
         verbose_name=_('publication date'), blank=True, null=True,
-        default=now(), db_index=True
+        default=now, db_index=True
     )
     publish = models.BooleanField(
         default=True, verbose_name=_('publish'),


### PR DESCRIPTION
Default for Submission.publish_date should be `now` rather than `now()` like it is for Subscription.create_date
