### PR TITLE
Django 1.8 support

### DIFF
--- a/newsletter/admin_utils.py
+++ b/newsletter/admin_utils.py
@@ -3,7 +3,11 @@ from django.http import Http404
 from functools import update_wrapper
 from django.utils.translation import ugettext_lazy as _
 
-from django.contrib.admin.util import unquote
+try:
+    from django.contrib.admin.utils import unquote
+except ImportError:  # Django < 1.7
+    from django.contrib.admin.util import unquote
+
 from django.utils.encoding import force_unicode
 
 
@@ -12,7 +16,7 @@ class ExtendibleModelAdminMixin(object):
             opts = self.model._meta
 
             try:
-                obj = self.queryset(request).get(pk=unquote(object_id))
+                obj = self.get_queryset(request).get(pk=unquote(object_id))
             except self.model.DoesNotExist:
                 # Don't raise Http404 just yet, because we haven't checked
                 # permissions yet. We don't want an unauthenticated user to

--- a/newsletter/forms.py
+++ b/newsletter/forms.py
@@ -1,7 +1,10 @@
 from django.utils.translation import ugettext_lazy as _
 
 from django import forms
-from django.forms.util import ValidationError
+try:
+    from django.forms.utils import ValidationError
+except ImportError:  # Django < 1.7
+    from django.forms.util import ValidationError
 
 from .utils import get_user_model
 User = get_user_model()

--- a/newsletter/migrations/0002_auto_20150416_1555.py
+++ b/newsletter/migrations/0002_auto_20150416_1555.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.manager
+import django.contrib.sites.managers
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('newsletter', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='newsletter',
+            name='email',
+            field=models.EmailField(help_text='Sender e-mail', max_length=254, verbose_name='e-mail'),
+        ),
+        migrations.AlterField(
+            model_name='subscription',
+            name='email_field',
+            field=models.EmailField(db_column=b'email', max_length=254, blank=True, null=True, verbose_name='e-mail', db_index=True),
+        ),
+    ]
+
+    # if using Django version 1.8 and later also apply AlterModelManagers and AlterField to GenericIPAddressField
+    if django.VERSION >= (1,8):
+        operations += [
+            migrations.AlterModelManagers(
+                name='newsletter',
+                managers=[
+                    (b'objects', django.db.models.manager.Manager()),
+                    (b'on_site', django.contrib.sites.managers.CurrentSiteManager()),
+                ],
+            ),
+            migrations.AlterField(
+                model_name='subscription',
+                name='ip',
+                field=models.GenericIPAddressField(null=True, verbose_name='IP address', blank=True),
+            )
+        ]

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -2,6 +2,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 from django.db import models
+
+# in Django 1.8 and later use GenericIPAddressField otherwise use IPAddressField
+from django import VERSION as DJANGO_VERSION
+if DJANGO_VERSION >= (1,8):
+    from django.db.models import GenericIPAddressField as IP_ADDRESS_FIELD
+else:
+    from django.db.models import IPAddressField as IP_ADDRESS_FIELD
+
 from django.db.models import permalink
 
 from django.template import Context, TemplateDoesNotExist
@@ -293,7 +301,8 @@ class Subscription(models.Model):
 
         super(Subscription, self).save(*args, **kwargs)
 
-    ip = models.IPAddressField(_("IP address"), blank=True, null=True)
+    # use GenericIPAddressField if available, otherwise use IPAddressField
+    ip = IP_ADDRESS_FIELD(_("IP address"), blank=True, null=True)
 
     newsletter = models.ForeignKey('Newsletter', verbose_name=_('newsletter'))
 


### PR DESCRIPTION
use GenericIPAddressField if available otherwise fall back to IPAddressField
fix admin.utils deprecation issue
add django 1.8 to travis tests
add migration to convert email fields to Django's new standard length