### PR TITLE
Change queryset to get_queryset for Django > 1.6

### DIFF
--- a/newsletter/admin_utils.py
+++ b/newsletter/admin_utils.py
@@ -12,7 +12,7 @@ class ExtendibleModelAdminMixin(object):
             opts = self.model._meta
 
             try:
-                obj = self.queryset(request).get(pk=unquote(object_id))
+                obj = self.get_queryset(request).get(pk=unquote(object_id))
             except self.model.DoesNotExist:
                 # Don't raise Http404 just yet, because we haven't checked
                 # permissions yet. We don't want an unauthenticated user to


### PR DESCRIPTION
Changed the old queryset to get_queryset in admin_utils.py to support Django version above 1.6.