### PR TITLE
Use Python's importlib, fix deprecation warning

### DIFF
--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -1,5 +1,6 @@
+from importlib import import_module
+
 from django.conf import settings as django_settings
-from django.utils.importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 
 from .utils import Singleton


### PR DESCRIPTION
There's a deprecation warning for `django.utils.importlib` in Django 1.8, and the fix is to simply use Python's importlib. Was added in Python 2.7, so now that 2.6 support is dropped it's fine to use unconditionally.