### PR TITLE
Import User the 1.7 way.

### DIFF
--- a/newsletter/utils.py
+++ b/newsletter/utils.py
@@ -1,18 +1,16 @@
 """ Generic helper functions """
-
 import logging
-logger = logging.getLogger(__name__)
-
 import random
+from datetime import datetime
+from django import VERSION
+from django.contrib.sites.models import Site
+
+logger = logging.getLogger(__name__)
 
 try:
     from hashlib import sha1
 except ImportError:
     from django.utils.hashcompat import sha_constructor as sha1
-
-from django.contrib.sites.models import Site
-
-from datetime import datetime
 
 # Possible actions that user can perform
 ACTIONS = ('subscribe', 'unsubscribe', 'update')
@@ -20,6 +18,12 @@ ACTIONS = ('subscribe', 'unsubscribe', 'update')
 
 def get_user_model():
     """ get_user_model compatibility wrapper. Returns active User model. """
+
+    # Django 1.7 and above
+    if VERSION[0] == 1 and VERSION[1] > 6:
+        from django.conf import settings
+        return settings.AUTH_USER_MODEL
+
     try:
         from django.contrib.auth import get_user_model
     except ImportError:


### PR DESCRIPTION
Sometimes User model cannot be imported this way (Django 1.8.6, Python 2.7.10):

    (venv)[20:51]est@14_04:/home/django/zyq2/zyq2$ ./manage.py check
    Traceback (most recent call last):
    File "./manage.py", line 10, in <module>
        execute_from_command_line(sys.argv)
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
        utility.execute()
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/core/management/__init__.py", line 328, in execute
        django.setup()
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/__init__.py", line 18, in setup
        apps.populate(settings.INSTALLED_APPS)
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/apps/registry.py", line 108, in populate
        app_config.import_models(all_models)
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/apps/config.py", line 198, in import_models
        self.models_module = import_module(models_module_name)
    File "/home/est/.pyenv/versions/2.7.10/lib/python2.7/importlib/__init__.py", line 37, in import_module
        __import__(name)
    File "/home/django/zyq2/env/lib/python2.7/site-packages/newsletter/models.py", line 26, in <module>
        User = get_user_model()
    File "/home/django/zyq2/env/lib/python2.7/site-packages/newsletter/utils.py", line 35, in get_user_model
        User = get_user_model()
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 150, in get_user_model
        return django_apps.get_model(settings.AUTH_USER_MODEL)
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/apps/registry.py", line 199, in get_model
        self.check_models_ready()
    File "/home/django/zyq2/env/lib/python2.7/site-packages/django/apps/registry.py", line 131, in check_models_ready
        raise AppRegistryNotReady("Models aren't loaded yet.")
    django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet.

Importing `User` as `settings.AUTH_USER_MODEL` solves the problem.