### PR TITLE
Cosmetic changes

### DIFF
--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -1,31 +1,16 @@
 import logging
-logger = logging.getLogger(__name__)
 
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.contrib.sites.managers import CurrentSiteManager
+from django.core.mail import EmailMultiAlternatives
 from django.db import models
-
-# in Django 1.8 and later use GenericIPAddressField otherwise use IPAddressField
-from django import VERSION as DJANGO_VERSION
-if DJANGO_VERSION >= (1,8):
-    from django.db.models import GenericIPAddressField as IP_ADDRESS_FIELD
-else:
-    from django.db.models import IPAddressField as IP_ADDRESS_FIELD
-
 from django.db.models import permalink
-
-from django.template import Context, TemplateDoesNotExist
+from django.template import Context
 from django.template.loader import select_template
-
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 from django.utils.timezone import now
-
-from django.core.mail import EmailMultiAlternatives
-
-from django.contrib.auth.models import User
-from django.contrib.sites.models import Site
-from django.contrib.sites.managers import CurrentSiteManager
-
-from django.conf import settings
 
 from sorl.thumbnail import ImageField
 
@@ -33,7 +18,17 @@ from .utils import (
     make_activation_code, get_default_sites, ACTIONS
 )
 
-AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', User)
+# in Django 1.8 and later use GenericIPAddressField otherwise use IPAddressField
+from django import VERSION as DJANGO_VERSION
+if DJANGO_VERSION >= (1, 8):
+    from django.db.models import GenericIPAddressField as IP_ADDRESS_FIELD
+else:
+    from django.db.models import IPAddressField as IP_ADDRESS_FIELD
+
+logger = logging.getLogger(__name__)
+
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 class Newsletter(models.Model):
@@ -477,7 +472,6 @@ class Article(models.Model):
 
     def __unicode__(self):
         return self.title
-
 
     def save(self):
         if self.pk is None:

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python# Run tests for application
+#!/usr/bin/env python  # Run tests for application
 # Source: https://stackoverflow.com/questions/3841725/how-to-launch-tests-for-django-reusable-app
 
 import sys
@@ -15,13 +15,13 @@ def runtests():
         django.setup()
 
     try:
-        # Django <= 1.8
-        from django.test.simple import DjangoTestSuiteRunner
-        test_runner = DjangoTestSuiteRunner(verbosity=1)
-    except ImportError:
-        # Django >= 1.8
+        # Django >= 1.6
         from django.test.runner import DiscoverRunner
         test_runner = DiscoverRunner(verbosity=1)
+    except ImportError:
+        # Django < 1.6
+        from django.test.simple import DjangoTestSuiteRunner
+        test_runner = DjangoTestSuiteRunner(verbosity=1)
 
     failures = test_runner.run_tests(['newsletter'])
     sys.exit(failures)


### PR DESCRIPTION
I was trying to upgrade a project to 1.7 and ran into issues with newsletter 0.5.2, so decided to fork and fix it. Luckily, I saw that some efforts were already done.

This PR reorganizes the imports a bit for a better coding style (group django imports alphabetically, then other third party libraries and then local imports), some small changes that my linter was complaining about and I removed the `contrib.auth.models.User` import as you can figure it out from settings.AUTH_USER_MODEL anyway.

I'd suggest dropping the AUTH_USER_MODEL shims alltogether and just use the setting, and mark 0.6 and up only available for Django 1.7 and up. That also enables you to drop South support.

I've also changed the testrunner to use the Discover runner where possible, and only fallback if needed. If you'd drop <1.7 support, that can also be removed.

Any idea when 0.6 might be on PyPI?