### PR TITLE
Display email on import confirmation page

### DIFF
--- a/newsletter/templates/admin/newsletter/subscription/confirmimportform.html
+++ b/newsletter/templates/admin/newsletter/subscription/confirmimportform.html
@@ -28,8 +28,8 @@
 <h1>{% trans "Confirm import" %}</h1>
 <div id="content-main">
     <ul>
-    {% for subscriber in subscribers.values %}
-    <li>{{ subscriber }}</li>
+    {% for email, name in subscribers.items %}
+    <li>{% if name %}{{ name }} &lt;{{ email }}&gt;{% else %}{{ email }}{% endif %}</li>
     {% endfor %}
     </ul>
     <form enctype="multipart/form-data" method="post">

--- a/newsletter/tests/files/addresses.vcf
+++ b/newsletter/tests/files/addresses.vcf
@@ -13,5 +13,5 @@ BEGIN:VCARD
 VERSION:3.0
 N:Martin;Jill
 FN:Jill Martin
-EMAIL;TYPE=INTERNET:jill.martin@example.org
+EMAIL;TYPE=INTERNET:jill@example.org
 END:VCARD

--- a/newsletter/tests/test_admin.py
+++ b/newsletter/tests/test_admin.py
@@ -54,6 +54,7 @@ class AdminTestCase(AdminTestMixin, TestCase):
         response = self.admin_import_file(source_file, ignore_errors)
 
         self.assertContains(response, "<h1>Confirm import</h1>")
+        self.assertContains(response, "<li>Jill Martin &lt;jill@example.org&gt;</li>")
 
         import_confirm_url = reverse(
             'admin:newsletter_subscription_import_confirm'


### PR DESCRIPTION
Currently, when importing an address with only email without
a name, the confirm page only display a bullet without any text
for that address. This patch adds the email address on each line
on the confirmation page.