### PR TITLE
Custom ArticleFormSet for more sensible Article sortorder, sortorder hidden by default

### DIFF
--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -205,10 +205,10 @@ class ArticleInline(AdminImageMixin, StackedInline):
     formset = ArticleFormSet
     fieldsets = (
         (None, {
-            'fields': ('title', 'sortorder', 'text')
+            'fields': ('title', 'text')
         }),
         (_('Optional'), {
-            'fields': ('url', 'image'),
+            'fields': ('sortorder', 'url', 'image'),
             'classes': ('collapse',)
         }),
     )

--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -36,7 +36,8 @@ from .models import (
 from django.utils.timezone import now
 
 from .admin_forms import (
-    SubmissionAdminForm, SubscriptionAdminForm, ImportForm, ConfirmForm
+    SubmissionAdminForm, SubscriptionAdminForm, ImportForm, ConfirmForm,
+    ArticleFormSet
 )
 from .admin_utils import ExtendibleModelAdminMixin, make_subscription
 
@@ -201,6 +202,7 @@ if (
 class ArticleInline(AdminImageMixin, StackedInline):
     model = Article
     extra = 2
+    formset = ArticleFormSet
     fieldsets = (
         (None, {
             'fields': ('title', 'sortorder', 'text')

--- a/newsletter/admin_forms.py
+++ b/newsletter/admin_forms.py
@@ -164,3 +164,15 @@ class SubmissionAdminForm(forms.ModelForm):
                 )
 
         return publish
+
+
+class ArticleFormSet(forms.BaseInlineFormSet):
+    """ Formset for articles yielding default sortoder. """
+
+    def __init__(self, *args, **kwargs):
+        super(ArticleFormSet, self).__init__(*args, **kwargs)
+
+        assert self.instance
+        next_sortorder = self.instance.get_next_article_sortorder()
+        for index, form in enumerate(self.extra_forms):
+            form.initial['sortorder'] = next_sortorder + index * 10

--- a/newsletter/migrations/0003_auto_20160226_1518.py
+++ b/newsletter/migrations/0003_auto_20160226_1518.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('newsletter', '0002_auto_20150416_1555'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='article',
+            name='sortorder',
+            field=models.PositiveIntegerField(help_text='Sort order determines the order in which articles are concatenated in a post.', verbose_name='sort order', blank=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='article',
+            unique_together=set([('post', 'sortorder')]),
+        ),
+    ]

--- a/newsletter/migrations/0003_auto_20160226_1518.py
+++ b/newsletter/migrations/0003_auto_20160226_1518.py
@@ -1,7 +1,22 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import logging
+logger = logging.getLogger(__name__)
 
 from django.db import migrations, models
+
+
+def renumerate_article_sortorder(apps, schema_editor):
+    """ Renumerate articles for consistent and guaranteed unique sortorder. """
+
+    Message = apps.get_model('newsletter', 'Message')
+
+    for message in Message.objects.all():
+        for index, article in enumerate(message.articles.all()):
+            # We're using the fact that articles are ordered by default
+
+            article.sortorder = (index + 1) * 10
+            article.save()
 
 
 class Migration(migrations.Migration):
@@ -16,6 +31,7 @@ class Migration(migrations.Migration):
             name='sortorder',
             field=models.PositiveIntegerField(help_text='Sort order determines the order in which articles are concatenated in a post.', verbose_name='sort order', blank=True),
         ),
+        migrations.RunPython(renumerate_article_sortorder),
         migrations.AlterUniqueTogether(
             name='article',
             unique_together=set([('post', 'sortorder')]),


### PR DESCRIPTION
In past versions, the sortorder used to be set using a (global, for all Articles) default. In f6c01803fc076746fd87e2085d1c52107ed4a703 as part of #103 this was changed to forcibly overriding it on save().

This patch dynamically creates unique initial values *per Message* while still creating new values when the default is not filled in (as is the case when adding new Articles using JS from the Admin).

It also hides the sortorder by default into the 'Optional' fields, as this is secundary with regards to the title and message, on the same level as the URL and image.