### PR TITLE
Admin Code Improvements

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -72,11 +72,11 @@ class AdminTestCase(AdminTestMixin, TestCase):
         response = self.client.get(changelist_url)
         self.assertContains(
             response,
-            '<a href="../message/?newsletter__id__exact=%s">Messages</a>' % self.newsletter.pk
+            '<a href="/admin/newsletter/message/?newsletter__id=%s">Messages</a>' % self.newsletter.pk
         )
         self.assertContains(
             response,
-            '<a href="../subscription/?newsletter__id__exact=%s">Subscriptions</a>' % self.newsletter.pk
+            '<a href="/admin/newsletter/subscription/?newsletter__id=%s">Subscriptions</a>' % self.newsletter.pk
         )
 
     def test_subscription_admin(self):
@@ -246,7 +246,7 @@ class AdminTestCase(AdminTestMixin, TestCase):
         response = self.client.get(changelist_url)
         self.assertContains(
             response,
-            '<a href="%d/preview/">Preview</a>' % self.message.pk,
+            '<a href="/admin/newsletter/message/%d/preview/">Preview</a>' % self.message.pk,
             html=True
         )
 


### PR DESCRIPTION
There's a couple different improvements in this PR:
- Use `format_html` instead of `allow_tags`, which was [deprecated in Django 1.9](https://docs.djangoproject.com/en/1.9/ref/contrib/admin/)
- Use `static` for getting the icon URLs, and pull out that logic to be reusable
- Use the `url` function instead of constructing relative URLs by hand
- Update `_getobj` to more closely match the latest version of that code from Django

Overall brings the code a bit closer to latest Django best practices for admin code.
