### PR TITLE
Settings for delays between emails, batches and the size of batches.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -70,6 +70,21 @@ Installation
     If not set, django-newsletter will fall back to Django's default TextField
     widget.
 
+#)  Configure delay and batch size (optional).
+
+    The delay between each email, batches en batch size can be specified with e.g.::
+
+        # Amount of seconds to wait between each email
+        ``NEWSLETTER_EMAIL_DELAY = 1``
+        
+        # Amount of seconds to waiw between each batch
+        ``NEWSLETTER_BATCH_DELAY = 60``
+        
+        # Number of emails in one batch
+        ``NEWSLETTER_BATCH_SIZE = 100``
+    
+    If the delays are not set, it will default to not sleeping.
+
 #)  Import subscription, unsubscription and archive URL's somewhere in your
     `urls.py`::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,16 +74,17 @@ Installation
 
     The delay between each email, batches en batch size can be specified with e.g.::
 
-        # Amount of seconds to wait between each email
-        ``NEWSLETTER_EMAIL_DELAY = 1``
+        # Amount of seconds to wait between each email. Here 100ms is used.
+        ``NEWSLETTER_EMAIL_DELAY = 0.1``
         
-        # Amount of seconds to waiw between each batch
+        # Amount of seconds to wait between each batch. Here one minute is used.
         ``NEWSLETTER_BATCH_DELAY = 60``
         
         # Number of emails in one batch
         ``NEWSLETTER_BATCH_SIZE = 100``
     
-    If the delays are not set, it will default to not sleeping.
+    For both delays, sub-second delays can also be used. If the delays are not 
+    set, it will default to not sleeping.
 
 #)  Import subscription, unsubscription and archive URL's somewhere in your
     `urls.py`::

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -588,11 +588,11 @@ class Submission(models.Model):
 
         try:
             for idx, subscription in enumerate(subscriptions, start=1):
-		if hasattr(settings, hasattr(settings, 'NEWSLETTER_EMAIL_DELAY'):
-		    time.sleep(settings.NEWSLETTER_EMAIL_DELAY)
-		if hasattr(settings, hasattr(settings, 'NEWSLETTER_BATCH_SIZE') and settings.NEWSLETTER_BATCH_SIZE > 0:
-		    if idx % settings.NEWSLETTER_BATCH_SIZE = 0:
-		        time.sleep(settings.NEWSLETTER_BATCH_DELAY)
+                if hasattr(settings, 'NEWSLETTER_EMAIL_DELAY'):
+                    time.sleep(settings.NEWSLETTER_EMAIL_DELAY)
+                if hasattr(settings, 'NEWSLETTER_BATCH_SIZE') and settings.NEWSLETTER_BATCH_SIZE > 0:
+                    if idx % settings.NEWSLETTER_BATCH_SIZE == 0:
+                        time.sleep(settings.NEWSLETTER_BATCH_DELAY)
                 self.send_message(subscription)
             self.sent = True
 

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -586,7 +587,12 @@ class Submission(models.Model):
         self.save()
 
         try:
-            for subscription in subscriptions:
+            for idx, subscription in enumerate(subscriptions, start=1):
+		if hasattr(settings, hasattr(settings, 'NEWSLETTER_EMAIL_DELAY'):
+		    time.sleep(settings.NEWSLETTER_EMAIL_DELAY)
+		if hasattr(settings, hasattr(settings, 'NEWSLETTER_BATCH_SIZE') and settings.NEWSLETTER_BATCH_SIZE > 0:
+		    if idx % settings.NEWSLETTER_BATCH_SIZE = 0:
+		        time.sleep(settings.NEWSLETTER_BATCH_DELAY)
                 self.send_message(subscription)
             self.sent = True
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ django-tinymce
 pytz
 webtest
 django-webtest
+mock

--- a/tests/test_mailing.py
+++ b/tests/test_mailing.py
@@ -175,12 +175,6 @@ class SubmitSubmissionTestCase(MailingTestCase):
         self.sub = Submission.from_message(self.m)
         self.sub.save()
     
-    def tearDown(self):
-        # Restore delay settings
-        settings.NEWSLETTER_EMAIL_DELAY = 0
-        settings.NEWSLETTER_BATCH_DELAY = 0
-        settings.NEWSLETTER_BATCH_SIZE = 0
-
     def test_submission(self):
         """ Assure initial Submission is in expected state. """
 
@@ -234,29 +228,26 @@ class SubmitSubmissionTestCase(MailingTestCase):
     def test_delayedsumbmission(self):
         """ Test delays between emails """
         
-        settings.NEWSLETTER_EMAIL_DELAY = 0.01
-        
         self.sub.prepared = True
         self.sub.publish_date = now() - timedelta(seconds=1)
         self.sub.save()
         
-        with unittest.mock.patch('time.sleep', return_value=None) as mock:
-            Submission.submit_queue()
+        with self.settings(NEWSLETTER_EMAIL_DELAY=0.01):
+            with unittest.mock.patch('time.sleep', return_value=None) as mock:
+                Submission.submit_queue()
         
         mock.assert_called_with(0.01)
     
     def test_delayedbatchsumbmission(self):
         """ Test delays between emails """
         
-        settings.NEWSLETTER_BATCH_SIZE = 1
-        settings.NEWSLETTER_BATCH_DELAY = 0.02
-        
         self.sub.prepared = True
         self.sub.publish_date = now() - timedelta(seconds=1)
         self.sub.save()
         
-        with unittest.mock.patch('time.sleep', return_value=None) as mock:
-            Submission.submit_queue()
+        with self.settings(NEWSLETTER_BATCH_SIZE=1, NEWSLETTER_BATCH_DELAY=0.02):
+            with unittest.mock.patch('time.sleep', return_value=None) as mock:
+                Submission.submit_queue()
         
         mock.assert_called_with(0.02)
 

--- a/tests/test_mailing.py
+++ b/tests/test_mailing.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import itertools
+import mock
 import six
 import time
 import unittest
@@ -233,10 +234,10 @@ class SubmitSubmissionTestCase(MailingTestCase):
         self.sub.save()
         
         with self.settings(NEWSLETTER_EMAIL_DELAY=0.01):
-            with unittest.mock.patch('time.sleep', return_value=None) as mock:
+            with mock.patch('time.sleep', return_value=None) as sleep_mock:
                 Submission.submit_queue()
         
-        mock.assert_called_with(0.01)
+        sleep_mock.assert_called_with(0.01)
     
     def test_delayedbatchsumbmission(self):
         """ Test delays between emails """
@@ -246,10 +247,10 @@ class SubmitSubmissionTestCase(MailingTestCase):
         self.sub.save()
         
         with self.settings(NEWSLETTER_BATCH_SIZE=1, NEWSLETTER_BATCH_DELAY=0.02):
-            with unittest.mock.patch('time.sleep', return_value=None) as mock:
+            with mock.patch('time.sleep', return_value=None) as sleep_mock:
                 Submission.submit_queue()
         
-        mock.assert_called_with(0.02)
+        sleep_mock.assert_called_with(0.02)
 
 
 class SubscriptionTestCase(UserTestCase, MailingTestCase):


### PR DESCRIPTION
For sending out large amounts of emails, it is generally a good idea to send them out in batches. This way your email servers aren't flooded and can recover in between batches.