### PR TITLE
enconding sender and recipient name as ascii in django<1.9

### DIFF
--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -734,6 +734,8 @@ class Submission(models.Model):
     )
 
 def get_address(name, email):
+    # Converting name to ascii for compatibility with django < 1.9.
+    # Remove this when django 1.8 is no longer supported.
     if LooseVersion(django.get_version()) < LooseVersion('1.9'):
         name = name.encode('ascii', 'ignore').decode('ascii').strip()
     if name:

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import django
 
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -15,6 +16,8 @@ from django.utils.translation import ugettext
 from django.utils.timezone import now
 
 from sorl.thumbnail import ImageField
+from distutils.version import LooseVersion
+
 
 from .compat import get_context, reverse
 from .utils import (
@@ -138,7 +141,7 @@ class Newsletter(models.Model):
         )
 
     def get_sender(self):
-        return u'%s <%s>' % (self.sender, self.email)
+        return get_address(self.sender, self.email)
 
     def get_subscriptions(self):
         logger.debug(u'Looking up subscribers for %s', self)
@@ -242,7 +245,6 @@ class Subscription(models.Model):
     def save(self, *args, **kwargs):
         """
         Perform some basic validation and state maintenance of Subscription.
-
         TODO: Move this code to a more suitable place (i.e. `clean()`) and
         cleanup the code. Refer to comment below and
         https://docs.djangoproject.com/en/dev/ref/models/instances/#django.db.models.Model.clean
@@ -342,10 +344,7 @@ class Subscription(models.Model):
         unique_together = ('user', 'email_field', 'newsletter')
 
     def get_recipient(self):
-        if self.name:
-            return u'%s <%s>' % (self.name, self.email)
-
-        return u'%s' % (self.email)
+        return get_address(self.name, self.email)
 
     def send_activation_email(self, action):
         assert action in ACTIONS, 'Unknown action: %s' % action
@@ -733,3 +732,11 @@ class Submission(models.Model):
         default=False, verbose_name=_('sending'),
         db_index=True, editable=False
     )
+
+def get_address(name, email):
+    if LooseVersion(django.get_version()) < LooseVersion('1.9'):
+        name = name.encode('ascii', 'ignore').decode('ascii').strip()
+    if name:
+        return u'%s <%s>' % (name, email)
+    else:
+        return u'%s' % email


### PR DESCRIPTION
This is a fix for django<1.9, which has a problem sending emails with non ascii names. I previously submitted the same pull request but tests were not passing, now they are.