### PR TITLE
Fix for Article and Submission save() methods

### DIFF
--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -671,7 +671,7 @@ class Submission(models.Model):
             submission.subscriptions = message.newsletter.get_subscriptions()
         return submission
 
-    def save(self):
+    def save(self, **kwargs):
         """ Set the newsletter from associated message upon saving. """
         assert self.message.newsletter
 

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -459,7 +459,7 @@ class Article(models.Model):
     def __str__(self):
         return self.title
 
-    def save(self):
+    def save(self, **kwargs):
         if self.sortorder is None:
             # If saving a new object get the next available Article ordering
             # as to assure uniqueness.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django-extensions
+django-extensions<2.0.1 # Bug causes build to fail: https://github.com/django-extensions/django-extensions/issues/1176
 Django>=1.8.18
 python-card-me<1.0
 ldif3<3.2


### PR DESCRIPTION
Without this, creating an Article instance directly (code, not admin interface) results in the following error:

TypeError: save() got an unexpected keyword argument 'force_insert'