### PR TITLE
Revert "Prevent triggering of a django-extensions bug"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django-extensions<2.0.1 # Bug causes build to fail: https://github.com/django-extensions/django-extensions/issues/1176
+django-extensions
 Django>=1.8.18
 python-card-me<1.0
 ldif3<3.2


### PR DESCRIPTION
This reverts commit 2f7e7077fa68cd18b06c05a393e93d522cdbe576 as the
django-extensions issue seems solved.

Ref: https://github.com/django-extensions/django-extensions/issues/1176#issuecomment-372072862