### PR TITLE
Permalink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       python: 2.7
     - env: DJANGO="Django==2.1.2"
       python: 2.7
+    - env: DJANGO="Django==2.1.2"
+      python: 3.4
 
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 env:
   - DJANGO="Django<1.12"    # Django 1.11.x
   - DJANGO="Django<2.1"     # Django 2.0.x
-  - DJANGO="Django==2.1.2"  # Django 2.1.2 LTS
+  - DJANGO="Django<2.2"     # Django 2.1.2 LTS
 
 cache:
   directories:
@@ -22,9 +22,9 @@ matrix:
     # Only supported Python/Django combinations
     - env: DJANGO="Django<2.1"
       python: 2.7
-    - env: DJANGO="Django==2.1.2"
+    - env: DJANGO="Django<2.2"
       python: 2.7
-    - env: DJANGO="Django==2.1.2"
+    - env: DJANGO="Django<2.2"
       python: 3.4
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 env:
   - DJANGO="Django<1.12"    # Django 1.11.x
   - DJANGO="Django<2.1"     # Django 2.0.x
-  - DJANGO="Django==2.1b1"  # Django 2.1b
+  - DJANGO="Django==2.1.2"  # Django 2.1.2 LTS
 
 cache:
   directories:
@@ -22,13 +22,9 @@ matrix:
     # Only supported Python/Django combinations
     - env: DJANGO="Django<2.1"
       python: 2.7
-    - env: DJANGO="Django==2.1b1"
+    - env: DJANGO="Django==2.1.2"
       python: 2.7
-    - env: DJANGO="Django==2.1b1"
-      python: 3.4
 
-  allow_failures:
-    - env: DJANGO="Django==2.1b1"
 
 # command to install dependencies
 install:

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -7,7 +7,6 @@ from django.contrib.sites.models import Site
 from django.contrib.sites.managers import CurrentSiteManager
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
-from django.db.models import permalink
 from django.template.loader import select_template
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
@@ -105,40 +104,20 @@ class Newsletter(models.Model):
         verbose_name = _('newsletter')
         verbose_name_plural = _('newsletters')
 
-    @permalink
     def get_absolute_url(self):
-        return (
-            'newsletter_detail', (),
-            {'newsletter_slug': self.slug}
-        )
+        return reverse('newsletter_detail', kwargs={'newsletter_slug': self.slug})
 
-    @permalink
     def subscribe_url(self):
-        return (
-            'newsletter_subscribe_request', (),
-            {'newsletter_slug': self.slug}
-        )
+        return reverse('newsletter_subscribe_request', kwargs={'newsletter_slug': self.slug})
 
-    @permalink
     def unsubscribe_url(self):
-        return (
-            'newsletter_unsubscribe_request', (),
-            {'newsletter_slug': self.slug}
-        )
+        return reverse('newsletter_unsubscribe_request', kwargs={'newsletter_slug': self.slug})
 
-    @permalink
     def update_url(self):
-        return (
-            'newsletter_update_request', (),
-            {'newsletter_slug': self.slug}
-        )
+        return reverse('newsletter_update_request', kwargs={'newsletter_slug': self.slug})
 
-    @permalink
     def archive_url(self):
-        return (
-            'newsletter_archive', (),
-            {'newsletter_slug': self.slug}
-        )
+        return reverse('newsletter_archive', kwargs={'newsletter_slug': self.slug})
 
     def get_sender(self):
         return get_address(self.sender, self.email)
@@ -390,27 +369,24 @@ class Subscription(models.Model):
             }
         )
 
-    @permalink
     def subscribe_activate_url(self):
-        return ('newsletter_update_activate', (), {
+        return reverse('newsletter_update_activate', kwargs={
             'newsletter_slug': self.newsletter.slug,
             'email': self.email,
             'action': 'subscribe',
             'activation_code': self.activation_code
         })
 
-    @permalink
     def unsubscribe_activate_url(self):
-        return ('newsletter_update_activate', (), {
+        return reverse('newsletter_update_activate', kwargs={
             'newsletter_slug': self.newsletter.slug,
             'email': self.email,
             'action': 'unsubscribe',
             'activation_code': self.activation_code
         })
 
-    @permalink
     def update_activate_url(self):
-        return ('newsletter_update_activate', (), {
+        return reverse('newsletter_update_activate', kwargs={
             'newsletter_slug': self.newsletter.slug,
             'email': self.email,
             'action': 'update',
@@ -677,13 +653,14 @@ class Submission(models.Model):
 
         return super(Submission, self).save()
 
-    @permalink
+    
+
     def get_absolute_url(self):
         assert self.newsletter.slug
         assert self.message.slug
 
-        return (
-            'newsletter_archive_detail', (), {
+        return reverse(
+            'newsletter_archive_detail', kwargs={
                 'newsletter_slug': self.newsletter.slug,
                 'year': self.publish_date.year,
                 'month': self.publish_date.month,


### PR DESCRIPTION
Solving the most pertinent issue [#258](https://github.com/dokterbob/django-newsletter/issues/258) on the use of the now deprecated permalink decorator.
I solved it by replacing it with reverse(view,kwargs={}) of the module newsletter.compact.
Also updated travis CI to build on Django 2.1.2 (where the issue was manifested)
Travis CI and coverall ok.