### PR TITLE
Add Django 2.2 and 3.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
   - pip install $DJANGO
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt
+  - pip install -e git://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail
   - pip install coveralls
 
 # Command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ install:
   - pip install $DJANGO
   - pip install -r requirements.txt
   - pip install -r requirements_test.txt
-  - pip install -e git://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail
   - pip install coveralls
 
 # Command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: python
+os: linux
 
-sudo: false
+language: python
 
 python:
   - 2.7
@@ -39,11 +39,7 @@ matrix:
     - env: DJANGO="Django<3.1"
       python: 3.5
 
-  allow_failures:
-    # Allow 3.0.x to fail, for now
-    - env: DJANGO="Django<3.1"
-
-# command to install dependencies
+# Command to install dependencies
 install:
   # Latest PIP uses wheel by default
   - pip install --upgrade pip
@@ -52,7 +48,7 @@ install:
   - pip install -r requirements_test.txt
   - pip install coveralls
 
-# command to run tests
+# Command to run tests
 script: coverage run setup.py test
 
 after_success:

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ python-card-me = "<1.0"
 ldif3 = "<3.2"
 chardet = "*"
 surlex = ">=0.2.0"
-sorl-thumbnail = {editable = true,git = "git://github.com/jazzband/sorl-thumbnail",ref = "4fe1854"}
+sorl-thumbnail = {editable = true,git = "git://github.com/jazzband/sorl-thumbnail",ref = "13bedfb7d2970809eda597e3ef79318a6fa80ac2"}
 six = "*"
 unicodecsv = "<0.15"
 Django = ">=1.11.27"

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ python-card-me = "<1.0"
 ldif3 = "<3.2"
 chardet = "*"
 surlex = ">=0.2.0"
-sorl-thumbnail = ">=12.5.0"
+sorl-thumbnail = {editable = true, git = "git://github.com/jazzband/sorl-thumbnail", ref = "4fe1854"}
 six = "*"
 unicodecsv = "<0.15"
 Django = "<2.3"
@@ -22,3 +22,4 @@ Pillow = ">=6.2.2"
 pip = "==18.0"
 
 [dev-packages]
+coverage = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,10 +14,10 @@ python-card-me = "<1.0"
 ldif3 = "<3.2"
 chardet = "*"
 surlex = ">=0.2.0"
-sorl-thumbnail = {editable = true, git = "git://github.com/jazzband/sorl-thumbnail", ref = "4fe1854"}
+sorl-thumbnail = {editable = true,git = "git://github.com/jazzband/sorl-thumbnail",ref = "4fe1854"}
 six = "*"
 unicodecsv = "<0.15"
-Django = "<2.3"
+Django = ">=1.11.27"
 Pillow = ">=6.2.2"
 pip = "==18.0"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b1b295248710b119a2c6f5c2af45e00f4ac9bb11fb094488f7603c2894e3ca6e"
+            "sha256": "e446ae94c2c41b2118738a0f4e5cafae06c4fd1f165f951d65d044de8f3dcf2d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,13 @@
         ]
     },
     "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0",
+                "sha256:ea448f92fc35a0ef4b1508f53a04c4670255a3f33d22a81c8fc9c872036adbe5"
+            ],
+            "version": "==3.2.3"
+        },
         "beautifulsoup4": {
             "hashes": [
                 "sha256:05fd825eb01c290877657a56df4c6e4c311b3965bda790c613a3d6fb01a5462a",
@@ -32,11 +39,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:662a1ff78792e3fd77f16f71b1f31149489434de4b62a74895bd5d6534e635a5",
-                "sha256:687c37153486cf26c3fdcbdd177ef16de38dc3463f094b5f9c9955d91f277b14"
+                "sha256:4f2c913303be4f874015993420bf0bd8fd2097a9c88e6b49c6a92f9bdd3fb13a",
+                "sha256:8c3575f81e11390893860d97e1e0154c47512f180ea55bd84ce8fa69ba8051ca"
             ],
             "index": "pypi",
-            "version": "==2.2.9"
+            "version": "==3.0.2"
         },
         "django-imperavi": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9e830e11405b6ea297d06a24046ee96220d7cf0574350048bb9ac8f36b57d55a"
+            "sha256": "b1b295248710b119a2c6f5c2af45e00f4ac9bb11fb094488f7603c2894e3ca6e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -135,12 +135,9 @@
             "version": "==1.13.0"
         },
         "sorl-thumbnail": {
-            "hashes": [
-                "sha256:8dfe5fda91a5047d1d35a0b9effe7b000764a01d648e15ca076f44e9c34b6dbd",
-                "sha256:d9e3f018d19293824803e4ffead96b19dfcd44fa7987cea392f50436817bef34"
-            ],
-            "index": "pypi",
-            "version": "==12.5.0"
+            "editable": true,
+            "git": "git://github.com/jazzband/sorl-thumbnail",
+            "ref": "4fe1854ee30e24adfc57884342517bbf506d0cd9"
         },
         "soupsieve": {
             "hashes": [
@@ -193,5 +190,43 @@
             "version": "==2.0.33"
         }
     },
-    "develop": {}
+    "develop": {
+        "coverage": {
+            "hashes": [
+                "sha256:189aac76d6e0d7af15572c51892e7326ee451c076c5a50a9d266406cd6c49708",
+                "sha256:1bf7ba2af1d373a1750888724f84cffdfc697738f29a353c98195f98fc011509",
+                "sha256:1f4ee8e2e4243971618bc16fcc4478317405205f135e95226c2496e2a3b8dbbf",
+                "sha256:225e79a5d485bc1642cb7ba02281419c633c216cdc6b26c26494ba959f09e69f",
+                "sha256:23688ff75adfa8bfa2a67254d889f9bdf9302c27241d746e17547c42c732d3f4",
+                "sha256:28f7f73b34a05e23758e860a89a7f649b85c6749e252eff60ebb05532d180e86",
+                "sha256:2d0cb9b1fe6ad0d915d45ad3d87f03a38e979093a98597e755930db1f897afae",
+                "sha256:47874b4711c5aeb295c31b228a758ce3d096be83dc37bd56da48ed99efb8813b",
+                "sha256:511ec0c00840e12fb4e852e4db58fa6a01ca4da72f36a9766fae344c3d502033",
+                "sha256:53e7438fef0c97bc248f88ba1edd10268cd94d5609970aaf87abbe493691af87",
+                "sha256:569f9ee3025682afda6e9b0f5bb14897c0db03f1a1dc088b083dd36e743f92bb",
+                "sha256:593853aa1ac6dcc6405324d877544c596c9d948ef20d2e9512a0f5d2d3202356",
+                "sha256:5b0a07158360d22492f9abd02a0f2ee7981b33f0646bf796598b7673f6bbab14",
+                "sha256:7ca3db38a61f3655a2613ee2c190d63639215a7a736d3c64cc7bbdb002ce6310",
+                "sha256:7d1cc7acc9ce55179616cf72154f9e648136ea55987edf84addbcd9886ffeba2",
+                "sha256:88b51153657612aea68fa684a5b88037597925260392b7bb4509d4f9b0bdd889",
+                "sha256:955ec084f549128fa2702f0b2dc696392001d986b71acd8fd47424f28289a9c3",
+                "sha256:b251c7092cbb6d789d62dc9c9e7c4fb448c9138b51285c36aeb72462cad3600e",
+                "sha256:bd82b684bb498c60ef47bb1541a50e6d006dde8579934dcbdbc61d67d1ea70d9",
+                "sha256:bfe102659e2ec13b86c7f3b1db6c9a4e7beea4255058d006351339e6b342d5d2",
+                "sha256:c1e4e39e43057396a5e9d069bfbb6ffeee892e40c5d2effbd8cd71f34ee66c4d",
+                "sha256:cb2b74c123f65e8166f7e1265829a6c8ed755c3cd16d7f50e75a83456a5f3fd7",
+                "sha256:cca38ded59105f7705ef6ffe1e960b8db6c7d8279c1e71654a4775ab4454ca15",
+                "sha256:cf908840896f7aa62d0ec693beb53264b154f972eb8226fb864ac38975590c4f",
+                "sha256:d095a7b473f8a95f7efe821f92058c8a2ecfb18f8db6677ae3819e15dc11aaae",
+                "sha256:d22b4297e7e4225ccf01f1aa55e7a96412ea0796b532dd614c3fcbafa341128e",
+                "sha256:d4a2b578a7a70e0c71f662705262f87a456f1e6c1e40ada7ea699abaf070a76d",
+                "sha256:ddeb42a3d5419434742bf4cc71c9eaa22df3b76808e23a82bd0b0bd360f1a9f1",
+                "sha256:e65a5aa1670db6263f19fdc03daee1d7dbbadb5cb67fd0a1f16033659db13c1d",
+                "sha256:eaad65bd20955131bcdb3967a4dea66b4e4d4ca488efed7c00d91ee0173387e8",
+                "sha256:f45fba420b94165c17896861bb0e8b27fb7abdcedfeb154895d8553df90b7b00"
+            ],
+            "index": "pypi",
+            "version": "==5.0.2"
+        }
+    }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e446ae94c2c41b2118738a0f4e5cafae06c4fd1f165f951d65d044de8f3dcf2d"
+            "sha256": "801cb2ddb141e5ce48d651ba878bc939c4cbc0cb07f50a5b6bf9d80040f76636"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -144,7 +144,7 @@
         "sorl-thumbnail": {
             "editable": true,
             "git": "git://github.com/jazzband/sorl-thumbnail",
-            "ref": "4fe1854ee30e24adfc57884342517bbf506d0cd9"
+            "ref": "13bedfb7d2970809eda597e3ef79318a6fa80ac2"
         },
         "soupsieve": {
             "hashes": [

--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from six import python_2_unicode_compatible
 import django
 
 from django.conf import settings
@@ -8,7 +9,6 @@ from django.contrib.sites.managers import CurrentSiteManager
 from django.core.mail import EmailMultiAlternatives
 from django.db import models
 from django.template.loader import select_template
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
@@ -653,7 +653,7 @@ class Submission(models.Model):
 
         return super(Submission, self).save()
 
-    
+
 
     def get_absolute_url(self):
         assert self.newsletter.slug

--- a/newsletter/templates/admin/newsletter/submission/change_form.html
+++ b/newsletter/templates/admin/newsletter/submission/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_form.html" %}
 
 {% load i18n admin_urls %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block extrahead %}
 {{ block.super }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ python-card-me<1.0
 ldif3<3.2
 chardet
 surlex>=0.2.0
-sorl-thumbnail>=12.5.0
 six
 unicodecsv<0.15
 Pillow
+# TODO: replace this with sorl-thumbnail>=12.6.0 when released
+-e git://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ ldif3<3.2
 chardet
 surlex>=0.2.0
 six
+# TODO: replace this with sorl-thumbnail>=12.6.0 when released
+# Pinning to specific commit (the 12.6.0 release), which is not yet on PyPI
+-e git://github.com/jazzband/sorl-thumbnail@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
 unicodecsv<0.15
 Pillow
-# TODO: replace this with sorl-thumbnail>=12.6.0 when released
--e git://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail

--- a/setup.py
+++ b/setup.py
@@ -42,14 +42,18 @@ except:
     warnings.warn('Could not read requirements_test.txt')
     TEST_REQUIREMENTS = None
 
-# TODO: remove this once sorl-thumbnail 12.6.0 released
-# Update requirements to accommodate pinning sorl-thumbnail to git repo
-# This section handles the issue of install_requires not support "-e" syntax
-REQUIREMENTS = REQUIREMENTS[:-134]
-REQUIREMENTS += 'sorl-thumbnail'
-DEPENDENCY_LINKS = [
-    'https://github.com/jazzband/sorl-thumbnail/tarball/master#egg=sorl-thumbnail'
-]
+# TODO: remove this once sorl-thumbnail 12.6.0 released to PyPI
+# setuptools cannot handle the syntax for an editable dependency as provided
+# by requirements.txt. This parses those lines to create an appropriate list
+# for install_requires and populates the needed dependency_links.
+REQUIREMENTS = REQUIREMENTS.splitlines()
+DEPENDENCY_LINKS = []
+
+for index, line in enumerate(REQUIREMENTS):
+    if line.startswith('-e git'):
+        link, requirement = line.split('#egg=')
+        REQUIREMENTS[index] = requirement
+        DEPENDENCY_LINKS.append(link)
 
 setup(
     name='django-newsletter',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,14 @@ except:
     warnings.warn('Could not read requirements_test.txt')
     TEST_REQUIREMENTS = None
 
+# TODO: remove this once sorl-thumbnail 12.6.0 released
+# Update requirements to accommodate pinning sorl-thumbnail to git repo
+# This section handles the issue of install_requires not support "-e" syntax
+REQUIREMENTS = REQUIREMENTS[:-134]
+REQUIREMENTS += 'sorl-thumbnail'
+DEPENDENCY_LINKS = [
+    'https://github.com/jazzband/sorl-thumbnail/tarball/master#egg=sorl-thumbnail'
+]
 
 setup(
     name='django-newsletter',
@@ -54,6 +62,8 @@ setup(
     ),
     long_description=README,
     install_requires=REQUIREMENTS,
+    # TODO: remove this once sorl-thumbnail 12.6.0 released
+    dependency_links=DEPENDENCY_LINKS,
     license='AGPL',
     author='Mathijs de Bruin',
     author_email='mathijs@mathijsfietst.nl',

--- a/setup.py
+++ b/setup.py
@@ -44,14 +44,19 @@ except:
 
 # TODO: remove this once sorl-thumbnail 12.6.0 released to PyPI
 # setuptools cannot handle the syntax for an editable dependency as provided
-# by requirements.txt. This parses those lines to create an appropriate list
-# for install_requires and populates the needed dependency_links.
+# by requirements.txt (specifically the "-e" portion). This parses those
+# lines to create an appropriate list for install_requires and populates the
+# needed dependency_links.
 REQUIREMENTS = REQUIREMENTS.splitlines()
 DEPENDENCY_LINKS = []
 
 for index, line in enumerate(REQUIREMENTS):
     if line.startswith('-e git'):
-        link, requirement = line.split('#egg=')
+        # Splits into the link and the package name
+        editable_link, requirement = line.split('#egg=')
+        # Removes "-e " from link (always the first 3 characters)
+        link = editable_link[3:]
+
         REQUIREMENTS[index] = requirement
         DEPENDENCY_LINKS.append(link)
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -55,6 +55,7 @@ TEMPLATES = [
 
 # Enable time-zone support
 USE_TZ = True
+TIME_ZONE = 'UTC'
 
 # Required for django-webtest to work
 STATIC_URL = '/static/'

--- a/tests/test_mailing.py
+++ b/tests/test_mailing.py
@@ -10,8 +10,6 @@ from datetime import timedelta
 
 from django.core import mail
 
-from django.test.utils import patch_logger
-from django.utils.six.moves import range
 from django.utils.timezone import now
 
 from newsletter.models import (
@@ -105,9 +103,7 @@ class ArticleTestCase(MailingTestCase):
 class MessageTestCase(MailingTestCase):
     def test_message_str(self):
         m1 = Message(title='Test message', slug='test-message')
-        with patch_logger('newsletter.models', 'warning') as warnings:
-            self.assertEqual(six.text_type(m1), "Test message in Test newsletter")
-        self.assertEqual(len(warnings), 0)
+        self.assertEqual(six.text_type(m1), "Test message in Test newsletter")
 
         m2 = Message.objects.create(
             title='Test message str',

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -17,7 +17,7 @@ from django.core import mail
 from django.utils import timezone
 from django.utils.encoding import force_text
 
-from django.test.utils import override_settings, patch_logger
+from django.test.utils import override_settings
 
 from newsletter.models import (
     Newsletter, Subscription, Submission, Message, get_default_sites
@@ -253,10 +253,10 @@ class UserNewsletterListTestCase(UserTestCase,
         Subscription.objects.all().delete()
 
         # A post without any form elements should fail, horribly
-        with patch_logger('newsletter.views', 'warning') as messages:
+        with self.assertLogs('newsletter.views', 'WARNING') as messages:
             self.client.post(self.list_url)
-        self.assertEqual(len(messages), 1)
-        self.assertIn("Invalid form post received", messages[0])
+        self.assertEqual(len(messages.output), 1)
+        self.assertIn("Invalid form post received", messages.output[0])
 
         # A post with correct management data with weird values
         # should cause the formset not to validate.
@@ -281,10 +281,10 @@ class UserNewsletterListTestCase(UserTestCase,
             count += 1
 
         # Post the form
-        with patch_logger('newsletter.views', 'warning') as messages:
+        with self.assertLogs('newsletter.views', 'WARNING') as messages:
             self.client.post(self.list_url, params)
-        self.assertEqual(len(messages), 1)
-        self.assertIn("Invalid form post received", messages[0])
+        self.assertEqual(len(messages.output), 1)
+        self.assertIn("Invalid form post received", messages.output[0])
 
         # Assert no subscriptions have been created
         self.assertFalse(
@@ -650,15 +650,15 @@ class AnonymousSubscribeTestCase(
         with override_settings(
             EMAIL_BACKEND='tests.utils.FailingEmailBackend'
         ):
-            with patch_logger('newsletter.views', 'error') as messages:
+            with self.assertLogs('newsletter.views', 'ERROR') as messages:
                 response = self.client.post(
                     self.subscribe_url, {
                         'name_field': self.testname,
                         'email_field': 'test@ifjoidjsufhdsidhsuufihs.dfs'
                     }
                 )
-            self.assertEqual(len(messages), 1)
-            self.assertIn("Connection refused", messages[0])
+            self.assertEqual(len(messages.output), 1)
+            self.assertIn("Connection refused", messages.output[0])
 
         self.assertTrue(response.context['error'])
 
@@ -958,12 +958,12 @@ class AnonymousSubscribeTestCase(
         with override_settings(
             EMAIL_BACKEND='tests.utils.FailingEmailBackend'
         ):
-            with patch_logger('newsletter.views', 'error') as messages:
+            with self.assertLogs('newsletter.views', 'ERROR') as messages:
                 response = self.client.post(
                     self.unsubscribe_url, {'email_field': self.testemail}
                 )
-            self.assertEqual(len(messages), 1)
-            self.assertIn("Connection refused", messages[0])
+            self.assertEqual(len(messages.output), 1)
+            self.assertIn("Connection refused", messages.output[0])
 
         self.assertTrue(response.context['error'])
 
@@ -1120,12 +1120,12 @@ class AnonymousSubscribeTestCase(
             EMAIL_BACKEND='tests.utils.FailingEmailBackend'
         ):
 
-            with patch_logger('newsletter.views', 'error') as messages:
+            with self.assertLogs('newsletter.views', 'ERROR') as messages:
                 response = self.client.post(
                     self.update_url, {'email_field': self.testemail}
                 )
-            self.assertEqual(len(messages), 1)
-            self.assertIn("Connection refused", messages[0])
+            self.assertEqual(len(messages.output), 1)
+            self.assertIn("Connection refused", messages.output[0])
 
         self.assertTrue(response.context['error'])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 import logging
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,63 @@ from django.template import loader, TemplateDoesNotExist
 
 from django_webtest import WebTest
 
+
+class AssertLogsMixin:
+    """Mixin to enable assertLogs method in Python 2.7.
+
+        patch_logger has similar functionality for Python 2.7, but is
+        removed in Django 3.0. This mixin reworks patch_logger so that
+        the assertLogs method can be used for any supported Django
+        version.
+    """
+    # TODO: Remove use of mixin when Django 1.11 support dropped
+    def assertLogs(self, logger=None, level=None):
+        # Use assertLogs context manager if present
+        try:
+            from unittest.case import _AssertLogsContext
+
+            return _AssertLogsContext(self, logger, level)
+        except ImportError:
+            # Fallback if Django version does not support assertLogs
+            import logging
+            from django.test.utils import patch_logger
+
+            class PatchLoggerResponse:
+                """Object to mimic AssertLogsContext response."""
+                def __init__(self, messages):
+                    self.output = messages
+
+            @contextmanager
+            def patch_logger(logger_name, log_level, log_kwargs=False):
+                """Replicating patch_logger functionality from Django 1.11.
+
+                    Cannot use original Django patch_logger because of how
+                    it returns its response. Have copied and modified it
+                    to return an object that mimics the assertLogs response.
+                """
+                logger_response = PatchLoggerResponse([])
+
+                def replacement(msg, *args, **kwargs):
+                    call = msg % args
+                    logger_response.output.append((call, kwargs) if log_kwargs else call)
+
+                logger = logging.getLogger(logger_name)
+                orig = getattr(logger, log_level)
+                setattr(logger, log_level, replacement)
+
+                try:
+                    yield logger_response
+                finally:
+                    setattr(logger, log_level, orig)
+
+                    if len(logger_response.output) == 0:
+                        raise self.failureException(
+                            "no logs of level {} or higher triggered on {}".format(
+                                log_level, logger_name
+                            )
+                        )
+
+            return patch_logger(logger, level.lower())
 
 class WebTestCase(WebTest):
     def setUp(self):
@@ -40,7 +98,7 @@ class WebTestCase(WebTest):
             self.assertEqual(instance, value)
 
 
-class MailTestCase(TestCase):
+class MailTestCase(AssertLogsMixin, TestCase):
     def get_email_list(self, email):
         if email:
             return (email,)
@@ -102,7 +160,7 @@ class MailTestCase(TestCase):
                 self.assertEqual(my_email.extra_headers[header], content)
 
 
-class UserTestCase(TestCase):
+class UserTestCase(AssertLogsMixin, TestCase):
     def setUp(self):
         super(UserTestCase, self).setUp()
 
@@ -127,7 +185,7 @@ class UserTestCase(TestCase):
         self.user.delete()
 
 
-class ComparingTestCase(TestCase):
+class ComparingTestCase(AssertLogsMixin, TestCase):
     def assertLessThan(self, value1, value2):
         self.assertTrue(value1 < value2)
 


### PR DESCRIPTION
# Major changes to allow Django 3.0 support
- Switched import of `python_2_unicode_compatible` to the `six` library, as it is removed from Django.
- Switched `patch_logger` (from Django) tests to `assertLogs` (from `unittest`), as `patch_logger` functionality is being dropped by Django.
- Created a temporary test mixin that enables support of `assertLogs` in Python 2.7; once Python 2.7 support is dropped this mixin can be removed and all tests should continue to pass.
- Pinned `sorl-thumbnail` to a specific commit that supports Django 1.11 to Django 3.0 - intent would be for this to be returned back to a released version as soon as the next release is made.

# Other minor changes
- Updated `.travis.yml` to remove unused statements and add recommended statements.

Relevant Issues: #291 #295 #296 #299 