### PR TITLE
Use ModelAdmin.opts for correct reverse in admin

### DIFF
--- a/newsletter/admin.py
+++ b/newsletter/admin.py
@@ -168,8 +168,9 @@ class SubmissionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
         if submission.sent or submission.prepared:
             messages.info(request, _("Submission already sent."))
             change_url = reverse(
-                'admin:newsletter_submission_change', args=[object_id]
+                'admin:%s_%s_change' % (self.opts.app_label, self.opts.model_name), args=[object_id]
             )
+
             return HttpResponseRedirect(change_url)
 
         submission.prepared = True
@@ -177,7 +178,7 @@ class SubmissionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
 
         messages.info(request, _("Your submission is being sent."))
 
-        changelist_url = reverse('admin:newsletter_submission_changelist')
+        changelist_url = reverse('admin:%s_%s_changelist' % (self.opts.app_label, self.opts.model_name))
         return HttpResponseRedirect(changelist_url)
 
     """ URLs """
@@ -305,9 +306,10 @@ class MessageAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
 
     def submit(self, request, object_id):
         submission = Submission.from_message(self._getobj(request, object_id))
+        opts = submission._meta
 
         change_url = reverse(
-            'admin:newsletter_submission_change', args=[submission.id])
+            'admin:%s_%s_change' % (opts.app_label, opts.model_name), args=[submission.id])
 
         return HttpResponseRedirect(change_url)
 
@@ -439,7 +441,7 @@ class SubscriptionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
                     form.cleaned_data['newsletter'].pk
 
                 confirm_url = reverse(
-                    'admin:newsletter_subscription_import_confirm'
+                    'admin:%s_%s_import_confirm' % (self.opts.app_label, self.opts.model_name)
                 )
                 return HttpResponseRedirect(confirm_url)
         else:
@@ -453,9 +455,8 @@ class SubscriptionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
 
     def subscribers_import_confirm(self, request):
         # If no addresses are in the session, start all over.
-
         if 'addresses' not in request.session:
-            import_url = reverse('admin:newsletter_subscription_import')
+            import_url = reverse('admin:%s_%s_import' % (self.opts.app_label, self.opts.model_name))
             return HttpResponseRedirect(import_url)
 
         addresses = request.session['addresses']
@@ -488,7 +489,7 @@ class SubscriptionAdmin(NewsletterAdminLinkMixin, ExtendibleModelAdminMixin,
                 )
 
                 changelist_url = reverse(
-                    'admin:newsletter_subscription_changelist'
+                    'admin:%s_%s_import_changelist' % (self.opts.app_label, self.opts.model_name)
                 )
                 return HttpResponseRedirect(changelist_url)
         else:


### PR DESCRIPTION
Make sure to use ModelAdmin.opts in admin.py in order to
get the correct app_label and model_name. This is important
when a subclass (e.g. of Newsletter) is used.