### PR TITLE
Adds VALIDATE_USER setting config, if False then don't check email in User model

### DIFF
--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -66,6 +66,7 @@ class NewsletterSettings(Settings):
     settings_prefix = 'NEWSLETTER'
 
     DEFAULT_CONFIRM_EMAIL = True
+    DEFAULT_VALIDATE_USER = True
 
     @property
     def DEFAULT_CONFIRM_EMAIL_SUBSCRIBE(self):
@@ -136,5 +137,17 @@ class NewsletterSettings(Settings):
         raise ImproperlyConfigured(
             "'%s' is not a supported thumbnail application." % THUMBNAIL
         )
+
+    @property
+    def VALIDATE_USER(self):
+        validate_user = getattr(
+            django_settings, "NEWSLETTER_VALIDATE_USER", ""
+        )
+
+        if validate_user:
+            return validate_user
+        else:
+            return self.DEFAULT_VALIDATE_USER
+
 
 newsletter_settings = NewsletterSettings()

--- a/newsletter/validators.py
+++ b/newsletter/validators.py
@@ -2,17 +2,20 @@ from django.contrib.auth import get_user_model
 from django.forms.utils import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from newsletter.settings import newsletter_settings
+
 
 def validate_email_nouser(email):
     """
     Check if the email address does not belong to an existing user.
     """
-    # Check whether we should be subscribed to as a user
-    User = get_user_model()
+    if newsletter_settings.VALIDATE_USER:
+        # Check whether we should be subscribed to as a user
+        User = get_user_model()
 
-    if User.objects.filter(email__exact=email).exists():
-        raise ValidationError(_(
-            "The e-mail address '%(email)s' belongs to a user with an "
-            "account on this site. Please log in as that user "
-            "and try again."
-        ) % {'email': email})
+        if User.objects.filter(email__exact=email).exists():
+            raise ValidationError(_(
+                "The e-mail address '%(email)s' belongs to a user with an "
+                "account on this site. Please log in as that user "
+                "and try again."
+            ) % {'email': email})


### PR DESCRIPTION
Need this functionality for the applications that don't have a web-based interface for normal users.
if NEWSLETTER_VALIDATE_USER is false in settings.py then it will not check for email in the User model.
fixes #369 