### PR TITLE
Validate user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 - Add NEWSLETTER_THUMBNAIL_QUALITY setting (defaults to 95)
 - Fix image_thumbnail_size to keep dimensions when image_thumbnail_width is not set
 - Fix unsubscribing from a dynamically generated newsletter when logged in
+- Add NEWSLETTER_VALIDATE_USER setting to skip checking if the email belongs to a user
 
 1.2.1 (2025-12-03)
 ------------------

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -44,7 +44,7 @@ Disable email confirmation for subscribe, unsubscribe and update actions for sub
 By default subscribe, unsubscribe and update requests made by a user who is
 not logged in need to be confirmed by clicking on an activation link in an
 email. If you want all requested actions to be performed without email
-confirmation, add following line to settings.py::
+confirmation, add following line to ``settings.py``::
 
     NEWSLETTER_CONFIRM_EMAIL = False
 
@@ -53,6 +53,18 @@ overridden for each of subscribe, unsubscribe and update actions, by adding
 ``NEWSLETTER_CONFIRM_EMAIL_SUBSCRIBE`` and/or
 ``NEWSLETTER_CONFIRM_EMAIL_UNSUBSCRIBE`` and/or
 ``NEWSLETTER_CONFIRM_EMAIL_UPDATE`` set to ``True`` or ``False``.
+
+Disabling the existing-user validation
+--------------------------------------
+Disable checking for existing users for the provided email address.
+
+By default, the subscribe/update/unsubscribe forms will reject email addresses
+that belong to a registered user, asking the visitor to login instead. If you
+want to bypass this check, add to ``settings.py``::
+
+    NEWSLETTER_VALIDATE_USER = False
+
+Defaults to ``True``.
 
 Configure rich text widget
 --------------------------

--- a/newsletter/settings.py
+++ b/newsletter/settings.py
@@ -73,6 +73,7 @@ class NewsletterSettings(Settings):
 
     DEFAULT_CONFIRM_EMAIL = True
     DEFAULT_THUMBNAIL_QUALITY = 95
+    DEFAULT_VALIDATE_USER = True
 
     @property
     def DEFAULT_CONFIRM_EMAIL_SUBSCRIBE(self):
@@ -151,6 +152,17 @@ class NewsletterSettings(Settings):
             use_https = True
 
         return use_https
+
+    @property
+    def VALIDATE_USER(self):
+        validate_user = getattr(
+            django_settings, "NEWSLETTER_VALIDATE_USER", None
+        )
+
+        if validate_user is None:
+            return self.DEFAULT_VALIDATE_USER
+
+        return validate_user
 
 
 newsletter_settings = NewsletterSettings()

--- a/newsletter/validators.py
+++ b/newsletter/validators.py
@@ -2,15 +2,20 @@ from django.contrib.auth import get_user_model
 from django.forms.utils import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from newsletter.settings import newsletter_settings
+
 
 def validate_email_nouser(email):
     """
     Check if the email address does not belong to an existing user.
     """
+    if not newsletter_settings.VALIDATE_USER:
+        return
+
     # Check whether we should be subscribed to as a user
     User = get_user_model()
 
-    if User.objects.filter(email__exact=email).exists():
+    if User.objects.filter(email__iexact=email).exists():
         raise ValidationError(_(
             "The e-mail address '%(email)s' belongs to a user with an "
             "account on this site. Please log in as that user "

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.forms.utils import ValidationError
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
@@ -23,3 +24,12 @@ class ValidatorTestCase(TestCase):
 
         with self.assertRaises(ValidationError):
             validate_email_nouser(user.email)
+
+    @override_settings(NEWSLETTER_VALIDATE_USER=False)
+    def test_validate_email_nouser_disabled(self):
+        """ With NEWSLETTER_VALIDATE_USER=False the validator is a no-op. """
+        User = get_user_model()
+        password = get_random_string(length=16)
+        User.objects.create_user('john', 'lennon@thebeatles.com', password)
+
+        validate_email_nouser('lennon@thebeatles.com')


### PR DESCRIPTION
Originally posted by @symbolic09 @symbolic-ac in https://github.com/jazzband/django-newsletter/pull/370 (original repo now deleted)

if NEWSLETTER_VALIDATE_USER is false in settings.py then it will not check for email in the User model.